### PR TITLE
feat: TimeOff reply cooldown

### DIFF
--- a/TimeOffApp.ts
+++ b/TimeOffApp.ts
@@ -14,6 +14,7 @@ import { IAppInfo } from '@rocket.chat/apps-engine/definition/metadata';
 import { TimeOffCommand } from './commands/TimeOffCommand';
 import { IMessage, IPostMessageSent } from '@rocket.chat/apps-engine/definition/messages';
 import { RoomType } from '@rocket.chat/apps-engine/definition/rooms';
+import { SettingType } from '@rocket.chat/apps-engine/definition/settings';
 import { UserRepository } from './repositories/UserRepository';
 import { TimeOffService } from './services/TimeOffService';
 import { AppNotifier } from './notifiers/AppNotifier';
@@ -21,6 +22,7 @@ import { PostMessageSentHandler } from './handlers/PostMessageSentHandler';
 import { TimeOffRepository } from './repositories/TimeOffRepository';
 import { TimeOffCache } from './TimeOffCache';
 import { UserService } from './services/UserService';
+import { APP_SETTINGS, DEFAULT_TIME_OFF_REPLY_COOLDOWN_HOURS } from './helpers/AppSettings';
 
 export class TimeOffApp extends App implements IPostMessageSent {
 	constructor(info: IAppInfo, logger: ILogger, accessors: IAppAccessors) {
@@ -32,6 +34,15 @@ export class TimeOffApp extends App implements IPostMessageSent {
 		_environmentRead: IEnvironmentRead,
 	): Promise<void> {
 		configuration.slashCommands.provideSlashCommand(new TimeOffCommand(this));
+		await configuration.settings.provideSetting({
+			id: APP_SETTINGS.TIME_OFF_REPLY_COOLDOWN_HOURS,
+			type: SettingType.NUMBER,
+			packageValue: DEFAULT_TIME_OFF_REPLY_COOLDOWN_HOURS,
+			required: false,
+			public: true,
+			i18nLabel: 'TimeOff Reply Cooldown (hours)',
+			i18nDescription: 'Hours to wait before sending another TimeOff message to the same sender.',
+		});
 	}
 
 	public async onEnable(
@@ -61,8 +72,27 @@ export class TimeOffApp extends App implements IPostMessageSent {
 		const timeOffService = new TimeOffService(timeOffRepository);
 
 		const notifier = new AppNotifier(this, read);
+		const cooldownHours = await this.getTimeOffReplyCooldownHours(read);
 
-		const handler = new PostMessageSentHandler(this, userService, timeOffService, notifier);
+		const handler = new PostMessageSentHandler(this, userService, timeOffService, notifier, cooldownHours);
 		await handler.handle(message);
+	}
+
+	private async getTimeOffReplyCooldownHours(read: IRead): Promise<number> {
+		try {
+			const settingValue = await read
+				.getEnvironmentReader()
+				.getSettings()
+				.getValueById(APP_SETTINGS.TIME_OFF_REPLY_COOLDOWN_HOURS);
+			const parsedSettingValue = Number(settingValue);
+
+			if (Number.isFinite(parsedSettingValue) && parsedSettingValue >= 0) {
+				return parsedSettingValue;
+			}
+		} catch (error) {
+			this.getLogger().error('[TimeOffApp] Error while reading time-off reply cooldown setting:', error);
+		}
+
+		return DEFAULT_TIME_OFF_REPLY_COOLDOWN_HOURS;
 	}
 }

--- a/commands/subcommands/Start.ts
+++ b/commands/subcommands/Start.ts
@@ -17,7 +17,7 @@ export async function startCommand(
 ): Promise<void> {
 	const currentUser = context.getSender();
 	const room = context.getRoom();
-	const notifier = new AppNotifier(this, read);
+	const notifier = new AppNotifier(app, read);
 
 	let message = context.getArguments().join(' ').replace(CommandEnum.START, '');
 	if (!message) {
@@ -29,6 +29,7 @@ export async function startCommand(
 		username: currentUser.username,
 		status: TimeOffStatus.ON_TIME_OFF,
 		message: message,
+		lastNotifiedAtBySenderId: {},
 	};
 
 	const timeOffRepository = new TimeOffRepository(app, read, persistence);

--- a/handlers/PostMessageSentHandler.ts
+++ b/handlers/PostMessageSentHandler.ts
@@ -6,6 +6,8 @@ import { IAppNotifier } from '../notifiers/IAppNotifier';
 import { TimeOffMessageFormatter } from '../helpers/TimeOffMessageFormatter';
 import { TimeOffApp } from '../TimeOffApp';
 import { IUserService } from '../services/IUserService';
+import { ITimeOff } from '../interfaces/ITimeOff';
+import { MILLISECONDS_PER_HOUR } from '../helpers/AppSettings';
 
 export class PostMessageSentHandler {
 	constructor(
@@ -13,6 +15,7 @@ export class PostMessageSentHandler {
 		private readonly userService: IUserService,
 		private readonly timeOffService: ITimeOffService,
 		private readonly notifier: IAppNotifier,
+		private readonly notificationCooldownHours: number,
 	) {}
 
 	public async handle(message: IMessage): Promise<void> {
@@ -23,9 +26,12 @@ export class PostMessageSentHandler {
 		if (!receiver) return;
 
 		const timeOffEntry = await this.timeOffService.getTimeOffByUserId(receiver.id);
-		if (timeOffEntry?.status === TimeOffStatus.ON_TIME_OFF) {
-			this.notifySender(message, sender, receiver, timeOffEntry.message);
+		if (!this.shouldSendNotification(timeOffEntry, sender.id)) {
+			return;
 		}
+
+		await this.notifySender(message, sender, receiver, timeOffEntry.message);
+		await this.persistLastNotifiedAtBySender(timeOffEntry, sender.id);
 	}
 
 	private async getSender(message: IMessage): Promise<IUser | undefined> {
@@ -48,8 +54,60 @@ export class PostMessageSentHandler {
 		return await this.userService.getUserById(receiverId);
 	}
 
-	private notifySender(message: IMessage, sender: IUser, receiver: IUser, timeOffMessage: string): void {
+	private async notifySender(
+		message: IMessage,
+		sender: IUser,
+		receiver: IUser,
+		timeOffMessage: string,
+	): Promise<void> {
 		const formattedMessage = TimeOffMessageFormatter.format(receiver.username, timeOffMessage);
-		this.notifier.notifyUser(message.room, sender, timeOffMessage, formattedMessage);
+		await this.notifier.notifyUser(message.room, sender, timeOffMessage, formattedMessage);
+	}
+
+	private shouldSendNotification(timeOffEntry: ITimeOff | undefined, senderId: string): timeOffEntry is ITimeOff {
+		if (!timeOffEntry || timeOffEntry.status !== TimeOffStatus.ON_TIME_OFF) {
+			return false;
+		}
+
+		return this.shouldNotifySender(timeOffEntry, senderId);
+	}
+
+	private shouldNotifySender(timeOffEntry: ITimeOff, senderId: string): boolean {
+		const lastNotifiedAt = timeOffEntry.lastNotifiedAtBySenderId?.[senderId];
+		if (!lastNotifiedAt) {
+			return true;
+		}
+
+		const cooldownMs = this.notificationCooldownHours * MILLISECONDS_PER_HOUR;
+		return Date.now() - lastNotifiedAt >= cooldownMs;
+	}
+
+	private async persistLastNotifiedAtBySender(timeOffEntry: ITimeOff, senderId: string): Promise<void> {
+		const now = Date.now();
+		const cleanedNotifications = this.cleanupExpiredNotifications(timeOffEntry.lastNotifiedAtBySenderId || {}, now);
+
+		const saveSucceeded = await this.timeOffService.saveTimeOff({
+			...timeOffEntry,
+			lastNotifiedAtBySenderId: {
+				...cleanedNotifications,
+				[senderId]: now,
+			},
+		});
+
+		if (!saveSucceeded) {
+			this.app.getLogger().error('[PostMessageSentHandler] Could not persist last-notified timestamp.');
+		}
+	}
+
+	private cleanupExpiredNotifications(notifications: Record<string, number>, now: number): Record<string, number> {
+		const cooldownMs = this.notificationCooldownHours * MILLISECONDS_PER_HOUR;
+
+		return Object.keys(notifications).reduce<Record<string, number>>((acc, senderId) => {
+			const timestamp = notifications[senderId];
+			if (now - timestamp < cooldownMs) {
+				acc[senderId] = timestamp;
+			}
+			return acc;
+		}, {});
 	}
 }

--- a/helpers/AppSettings.ts
+++ b/helpers/AppSettings.ts
@@ -1,0 +1,7 @@
+export const APP_SETTINGS = {
+	TIME_OFF_REPLY_COOLDOWN_HOURS: 'timeoff_reply_cooldown_hours',
+} as const;
+
+export const DEFAULT_TIME_OFF_REPLY_COOLDOWN_HOURS = 12;
+
+export const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;

--- a/interfaces/ITimeOff.ts
+++ b/interfaces/ITimeOff.ts
@@ -5,4 +5,5 @@ export interface ITimeOff {
 	username: string;
 	message: string;
 	status: TimeOffStatus;
+	lastNotifiedAtBySenderId?: Record<string, number>;
 }

--- a/notifiers/IAppNotifier.ts
+++ b/notifiers/IAppNotifier.ts
@@ -3,5 +3,5 @@ import { IUser } from '@rocket.chat/apps-engine/definition/users';
 import { LayoutBlock } from '@rocket.chat/ui-kit';
 
 export interface IAppNotifier {
-	notifyUser(room: IRoom, sender: IUser, message?: string, messageBlocks?: LayoutBlock[]): void;
+	notifyUser(room: IRoom, sender: IUser, message?: string, messageBlocks?: LayoutBlock[]): Promise<void>;
 }


### PR DESCRIPTION
## Summary

- Adds a configurable cooldown period to prevent the app from sending repeated TimeOff notifications to the same sender within a set time window
- Introduces a new app setting (`timeoff_reply_cooldown_hours`, default: 12h) configurable via the Rocket.Chat admin panel
- Tracks per-sender last-notified timestamps on the `ITimeOff` record and cleans up expired entries automatically

## Test plan

- [ ] Set a time-off message and send a message from another user — confirm the notification fires
- [ ] Send another message from the same user within the cooldown window — confirm no second notification is sent
- [ ] Wait for the cooldown to expire (or set it to 0) — confirm the notification fires again
- [ ] Change the cooldown setting in the admin panel and verify the new value is respected
- [ ] Verify the app starts cleanly and the new setting appears in the admin panel