### PR TITLE
UX improvements: clearer copy, consistent naming, no fabricated replies

### DIFF
--- a/commands/TimeOffCommand.ts
+++ b/commands/TimeOffCommand.ts
@@ -9,8 +9,8 @@ import { statusCommand } from './subcommands/Status';
 
 export class TimeOffCommand implements ISlashCommand {
 	public command = 'time-off';
-	public i18nParamsExample = '';
-	public i18nDescription = '';
+	public i18nParamsExample = 'Time_Off_Command_Params_Example';
+	public i18nDescription = 'Time_Off_Command_Description';
 	public providesPreview = false;
 
 	constructor(private readonly app: TimeOffApp) {}

--- a/commands/subcommands/Help.ts
+++ b/commands/subcommands/Help.ts
@@ -8,7 +8,7 @@ export async function helpCommand(app: TimeOffApp, context: SlashCommandContext,
 	const room = context.getRoom();
 
 	const message =
-		`*Time-Off Help*\n\n` +
+		`*Time-off Help*\n\n` +
 		`*Commands*\n` +
 		`• \`/time-off start\` starts new time off period\n` +
 		`• \`/time-off start [message]\` start a new time off period with a custom message\n` +

--- a/commands/subcommands/Help.ts
+++ b/commands/subcommands/Help.ts
@@ -10,10 +10,11 @@ export async function helpCommand(app: TimeOffApp, context: SlashCommandContext,
 	const message =
 		`*Time Off App Help*\n\n` +
 		`*Commands*\n` +
-		`• \`/time-off start\` - Start a new time off\n` +
-		`• \`/time-off end\` - End an existing time off\n` +
-		`• \`/time-off status\` - Check the current time off status\n` +
-		`• \`/time-off help\` - Display this help message\n`;
+		`• \`/time-off start\` starts new time off period\n` +
+		`• \`/time-off start [message]\` start a new time off period with a custom message\n` +
+		`• \`/time-off end\` ends current time off period\n` +
+		`• \`/time-off status\` shows current time off status\n` +
+		`• \`/time-off help\` shows this list\n`;
 
 	const notifier = new AppNotifier(app, read);
 	await notifier.notifyUser(room, sender, message);

--- a/commands/subcommands/Help.ts
+++ b/commands/subcommands/Help.ts
@@ -8,7 +8,7 @@ export async function helpCommand(app: TimeOffApp, context: SlashCommandContext,
 	const room = context.getRoom();
 
 	const message =
-		`*Time Off App Help*\n\n` +
+		`*Time-Off Help*\n\n` +
 		`*Commands*\n` +
 		`• \`/time-off start\` starts new time off period\n` +
 		`• \`/time-off start [message]\` start a new time off period with a custom message\n` +

--- a/commands/subcommands/Start.ts
+++ b/commands/subcommands/Start.ts
@@ -20,13 +20,12 @@ export async function startCommand(
 	const notifier = new AppNotifier(app, read);
 
 	const customMessage = context.getArguments().join(' ').replace(CommandEnum.START, '').trim();
-	const message = customMessage || NOTIFICATION_MESSAGES.default_reply_message;
 
 	const timeOffEntry: ITimeOff = {
 		coreUserId: currentUser.id,
 		username: currentUser.username,
 		status: TimeOffStatus.ON_TIME_OFF,
-		message: message,
+		message: customMessage || undefined,
 		lastNotifiedAtBySenderId: {},
 	};
 

--- a/commands/subcommands/Start.ts
+++ b/commands/subcommands/Start.ts
@@ -19,10 +19,8 @@ export async function startCommand(
 	const room = context.getRoom();
 	const notifier = new AppNotifier(app, read);
 
-	let message = context.getArguments().join(' ').replace(CommandEnum.START, '');
-	if (!message) {
-		message = NOTIFICATION_MESSAGES.default_reply_message;
-	}
+	const customMessage = context.getArguments().join(' ').replace(CommandEnum.START, '').trim();
+	const message = customMessage || NOTIFICATION_MESSAGES.default_reply_message;
 
 	const timeOffEntry: ITimeOff = {
 		coreUserId: currentUser.id,
@@ -36,6 +34,8 @@ export async function startCommand(
 	const timeOffService = new TimeOffService(timeOffRepository);
 	const savedTimeOff = await timeOffService.saveTimeOff(timeOffEntry);
 
-	const notificationMessage = !savedTimeOff ? NOTIFICATION_MESSAGES.error : NOTIFICATION_MESSAGES.started;
+	const notificationMessage = !savedTimeOff
+		? NOTIFICATION_MESSAGES.error
+		: NOTIFICATION_MESSAGES.started(customMessage || undefined);
 	await notifier.notifyUser(room, currentUser, notificationMessage);
 }

--- a/commands/subcommands/Status.ts
+++ b/commands/subcommands/Status.ts
@@ -30,7 +30,9 @@ export async function statusCommand(
 	}
 
 	if (timeOffEntry.status === TimeOffStatus.ON_TIME_OFF) {
-		notificationMessage = `${NOTIFICATION_MESSAGES.status_in}${timeOffEntry.message}`;
+		notificationMessage = timeOffEntry.message
+			? `${NOTIFICATION_MESSAGES.status_in}${timeOffEntry.message}`
+			: NOTIFICATION_MESSAGES.status_in_no_message;
 	} else {
 		notificationMessage = `${NOTIFICATION_MESSAGES.status_out}`;
 	}

--- a/handlers/PostMessageSentHandler.ts
+++ b/handlers/PostMessageSentHandler.ts
@@ -58,10 +58,13 @@ export class PostMessageSentHandler {
 		message: IMessage,
 		sender: IUser,
 		receiver: IUser,
-		timeOffMessage: string,
+		timeOffMessage?: string,
 	): Promise<void> {
 		const formattedMessage = TimeOffMessageFormatter.format(receiver.username, timeOffMessage);
-		await this.notifier.notifyUser(message.room, sender, timeOffMessage, formattedMessage);
+		const fallbackText = timeOffMessage
+			? `${receiver.username} is currently on time off. They left the following message: ${timeOffMessage}`
+			: `${receiver.username} is currently on time off.`;
+		await this.notifier.notifyUser(message.room, sender, fallbackText, formattedMessage);
 	}
 
 	private shouldSendNotification(timeOffEntry: ITimeOff | undefined, senderId: string): timeOffEntry is ITimeOff {

--- a/helpers/NotificationMessage.ts
+++ b/helpers/NotificationMessage.ts
@@ -4,6 +4,6 @@ export const NOTIFICATION_MESSAGES = {
 	ended: `Welcome back! You are no longer marked as Time Off.`,
 	not_started: `*Time-off off*\nI will not automatically reply to any direct messages you receive.`,
 	status_in: `You are currently marked as Time Off. Your message is: `,
-	status_out: `You are \`not\` marked as Time Off.`,
+	status_out: `*Time-off off*\nI will not automatically reply to any direct messages you receive.`,
 	error: `An error occurred while updating your Time Off status. Please try again later.`,
 };

--- a/helpers/NotificationMessage.ts
+++ b/helpers/NotificationMessage.ts
@@ -1,5 +1,18 @@
 export const NOTIFICATION_MESSAGES = {
-	started: `You are marked as Time Off, we will see you when you get back. Use \`/time-off end\` to end your time off.`,
+	started: (customMessage?: string): string => {
+		const intro = `*Time off on*\nI will automatically reply to any direct messages you receive to let the sender know you're on time off.`;
+		const reminder = `Remember to use the \`/time-off end\` command when you get back.`;
+
+		if (customMessage) {
+			const quoted = customMessage
+				.split('\n')
+				.map((line) => `> ${line}`)
+				.join('\n');
+			return `${intro}\n\nI will also include the following custom message:\n${quoted}\n\n${reminder}`;
+		}
+
+		return `${intro}\n\n${reminder}`;
+	},
 	default_reply_message: `I am out of office, I will get back to you soon.`,
 	ended: `Welcome back! You are no longer marked as Time Off.`,
 	not_started: `*Time-off off*\nI will not automatically reply to any direct messages you receive.`,

--- a/helpers/NotificationMessage.ts
+++ b/helpers/NotificationMessage.ts
@@ -11,12 +11,12 @@ export const NOTIFICATION_MESSAGES = {
 			return `${intro}\n\nI will also include the following custom message:\n${quoted}\n\n${reminder}`;
 		}
 
-		return `${intro}\n\n${reminder}`;
+		return `${intro}\n\nYou have not set a custom reply message.\n\n${reminder}`;
 	},
-	default_reply_message: `I am out of office, I will get back to you soon.`,
 	ended: `Welcome back! You are no longer marked as Time Off.`,
 	not_started: `*Time-off off*\nI will not automatically reply to any direct messages you receive.`,
 	status_in: `You are currently marked as Time Off. Your message is: `,
+	status_in_no_message: `You are currently marked as Time Off. You have not set a custom reply message.`,
 	status_out: `*Time-off off*\nI will not automatically reply to any direct messages you receive.`,
 	error: `An error occurred while updating your Time Off status. Please try again later.`,
 };

--- a/helpers/NotificationMessage.ts
+++ b/helpers/NotificationMessage.ts
@@ -2,7 +2,7 @@ export const NOTIFICATION_MESSAGES = {
 	started: `You are marked as Time Off, we will see you when you get back. Use \`/time-off end\` to end your time off.`,
 	default_reply_message: `I am out of office, I will get back to you soon.`,
 	ended: `Welcome back! You are no longer marked as Time Off.`,
-	not_started: `You are not marked as Time Off. Use \`/time-off start\` to start your time off.`,
+	not_started: `*Time-off off*\nI will not automatically reply to any direct messages you receive.`,
 	status_in: `You are currently marked as Time Off. Your message is: `,
 	status_out: `You are \`not\` marked as Time Off.`,
 	error: `An error occurred while updating your Time Off status. Please try again later.`,

--- a/helpers/TimeOffMessageFormatter.ts
+++ b/helpers/TimeOffMessageFormatter.ts
@@ -1,25 +1,36 @@
 import { LayoutBlock } from '@rocket.chat/ui-kit';
 
 export class TimeOffMessageFormatter {
-	public static format(username: string, message: string): LayoutBlock[] {
-		return [
+	public static format(username: string, message?: string): LayoutBlock[] {
+		const headerText = message
+			? `${username} is currently on time off. They left the following message:`
+			: `${username} is currently on time off.`;
+
+		const blocks: LayoutBlock[] = [
 			{
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `${username} is currently *unavailable* to answer your message, however they left the following message:\n\n`,
-				},
-			},
-			{
-				type: 'section',
-				text: {
-					type: 'mrkdwn',
-					text: message
-						.split('\n')
-						.map((line) => `> ${line}`)
-						.join('\n'),
+					text: headerText,
 				},
 			},
 		];
+
+		if (message) {
+			const quoted = message
+				.split('\n')
+				.map((line) => `> ${line}`)
+				.join('\n');
+
+			blocks.push({
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: quoted,
+				},
+			});
+		}
+
+		return blocks;
 	}
 }

--- a/helpers/TimeOffMessageFormatter.ts
+++ b/helpers/TimeOffMessageFormatter.ts
@@ -11,14 +11,14 @@ export class TimeOffMessageFormatter {
 				},
 			},
 			{
-				type: 'preview',
-				title: [],
-				description: [
-					{
-						type: 'mrkdwn',
-						text: message,
-					},
-				],
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: message
+						.split('\n')
+						.map((line) => `> ${line}`)
+						.join('\n'),
+				},
 			},
 		];
 	}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,4 @@
+{
+	"Time_Off_Command_Description": "Manage your time off — start, end, or check your status",
+	"Time_Off_Command_Params_Example": "start | end | status | help"
+}

--- a/interfaces/ITimeOff.ts
+++ b/interfaces/ITimeOff.ts
@@ -3,7 +3,7 @@ import { TimeOffStatus } from '../enums/Status';
 export interface ITimeOff {
 	coreUserId: string;
 	username: string;
-	message: string;
+	message?: string;
 	status: TimeOffStatus;
 	lastNotifiedAtBySenderId?: Record<string, number>;
 }

--- a/notifiers/AppNotifier.ts
+++ b/notifiers/AppNotifier.ts
@@ -6,7 +6,7 @@ import { LayoutBlock } from '@rocket.chat/ui-kit';
 import { TimeOffApp } from '../TimeOffApp';
 
 export class AppNotifier implements IAppNotifier {
-	private readonly TimeOffName: string = 'Time-Off';
+	private readonly TimeOffName: string = 'Time-off';
 
 	constructor(private readonly app: TimeOffApp, private readonly read: IRead) {}
 

--- a/notifiers/AppNotifier.ts
+++ b/notifiers/AppNotifier.ts
@@ -6,7 +6,7 @@ import { LayoutBlock } from '@rocket.chat/ui-kit';
 import { TimeOffApp } from '../TimeOffApp';
 
 export class AppNotifier implements IAppNotifier {
-	private readonly TimeOffName: string = 'TimeOff Bot';
+	private readonly TimeOffName: string = 'Time-Off';
 
 	constructor(private readonly app: TimeOffApp, private readonly read: IRead) {}
 


### PR DESCRIPTION
## Goals

Improve the Time-Off app's user-facing copy and behavior so it reads clearly, uses consistent naming, and never puts words in a user's mouth. These are UX refinements gathered from design feedback — no functional/data-model changes beyond how the reply message is stored.

## Changes

**Naming & copy consistency**
- Bot reply alias now shows as **Time-off** instead of "TimeOff Bot".
- Normalized the app/help naming to "Time-off" across the help header and command list.

**Slash command discoverability**
- Added an i18n description and params example so typing `/time-off` (before Enter) shows a friendly hint: *"Manage your time off — start, end, or check your status"* with `start | end | status | help`.

**Clearer start confirmation**
- Reworded the `/time-off start` confirmation to emphasize the app **only auto-replies to DMs** and that the user must **manually** end with `/time-off end`.
- When a custom message is provided, it's echoed back as a blockquote.
- When no custom message is provided, the confirmation notes that no custom reply message was set.

**Stop sending fabricated messages on the user's behalf**
- Removed the hardcoded default out-of-office reply ("I am out of office…") that the user never wrote.
- When no custom message is set, senders now simply see that the user is on time off; when one is set, it's shown as a blockquote.
- `message` is now optional on the time-off entry; `/time-off status` reflects whether a custom reply message was set.

**DM reply presentation**
- Replaced the `preview` layout block with a section that renders the user's message as a `>` blockquote.

## Notes
- No migration needed — the bot alias is applied per message, so already-installed instances pick up the new name on redeploy.
